### PR TITLE
add bounce animation and prompt to authorize button, show less text on load

### DIFF
--- a/public/content.js
+++ b/public/content.js
@@ -6,7 +6,9 @@ const content = [
   <div class="float-left mr-4">
     <img class="w-48 inline rounded-md shadow-md dark:border dark:border-gray-700" src="https://meanitsoftware.s3.us-east-1.amazonaws.com/bear1.png" />
   </div>
-  <p>Welcome to a tour of the <a class="text-oso-purple-500" href="https://www.osohq.com/docs/modeling-in-polar/reference">Polar authorization language.</a></p>
+  <p>👋 Welcome! This is an interactive playground to learn how authorization works using Oso and <a class="text-oso-purple-500" href="https://www.osohq.com/docs/modeling-in-polar/reference">Polar authorization language.</a></p>
+  <p class="mt-2">Want to get started? Click <span class="font-bold">authorize</span> on the right to see if the authorization check succeeded. Modify the policy and facts to try it out!</p>
+  <h2 class="text-lg font-bold mt-4">More Info</h2>
   <p class="mt-2">The tour is divided into a list of modules that you can access by clicking on <a class="text-oso-purple-500">A Tour of Polar</a> on the top left of the page. You can also view the table of contents at any time by clicking on the menu on the top right of the page.</p>
   <p class="mt-2">The code on the right contains a Polar policy. Polar is declarative language designed to express authorization logic in a readable, rule-based format.</p>
   <p class="mt-2">Polar authorization requests typically take the form "Can this actor perform some action on this resource?" The code on the right contains a minimal policy which indicates that users can read items if they are an admin.</p>

--- a/public/content.js
+++ b/public/content.js
@@ -7,12 +7,19 @@ const content = [
     <img class="w-48 inline rounded-md shadow-md dark:border dark:border-gray-700" src="https://meanitsoftware.s3.us-east-1.amazonaws.com/bear1.png" />
   </div>
   <p>Welcome to a tour of the <a class="text-oso-purple-500" href="https://www.osohq.com/docs/modeling-in-polar/reference">Polar authorization language.</a></p>
-  <p class="mt-2">The tour is divided into a list of modules that you can access by clicking on <a class="text-oso-purple-500">A Tour of Polar</a> on the top left of the page. You can also view the table of contents at any time by clicking on the menu on the top right of the page.</p>
-  <p class="mt-2">The code on the right contains a Polar policy. Polar is declarative language designed to express authorization logic in a readable, rule-based format.</p>
-  <p class="mt-2">Polar authorization requests typically take the form "Can this actor perform some action on this resource?" The code on the right contains a minimal policy which indicates that users can read items if they are an admin.</p>
-  <p class="mt-2">Facts define authorization data. This example has one fact by default: user 'alice' has the 'admin' role on the item 'foo'. According to the policy, this means Alice can read Item 'foo'.</p>
-  <img class="mx-auto my-2 w-2/3 cursor-pointer dark:bg-gray-400 rounded-md" src="https://meanitsoftware.s3.us-east-1.amazonaws.com/architecture-diagrams-white.png" onclick="openImageModal(this.src)">
-  <p class="mt-2">Click "Authorize" to execute the authorization query with the provided policy. You should see "Result: allowed" in the results panel once the policy has been run, which means the authorization query succeeded.</p>
+  <p class="mt-1">Click <span class="font-bold">Authorize</span> to see if access is granted. Modify the rules and facts to learn!</p>
+
+  <button id="moreContentOpen" class="mt-1 bg-oso-purple-600 hover:bg-oso-purple-500 text-white px-4 py-2 rounded-md disabled:bg-slate-500 dark:bg-oso-purple-800 dark:hover:bg-oso-purple-700">
+    Read More
+  </button>
+  <div id="moreContent" class="hidden">
+    <p class="mt-2">The tour is divided into a list of modules that you can access by clicking on <a class="text-oso-purple-500">A Tour of Polar</a> on the top left of the page. You can also view the table of contents at any time by clicking on the menu on the top right of the page.</p>
+    <p class="mt-2">The code on the right contains a Polar policy. Polar is declarative language designed to express authorization logic in a readable, rule-based format.</p>
+    <p class="mt-2">Polar authorization requests typically take the form "Can this actor perform some action on this resource?" The code on the right contains a minimal policy which indicates that users can read items if they are an admin.</p>
+    <p class="mt-2">Facts define authorization data. This example has one fact by default: user 'alice' has the 'admin' role on the item 'foo'. According to the policy, this means Alice can read Item 'foo'.</p>
+    <img class="mx-auto my-2 w-2/3 cursor-pointer dark:bg-gray-400 rounded-md" src="https://meanitsoftware.s3.us-east-1.amazonaws.com/architecture-diagrams-white.png" onclick="openImageModal(this.src)">
+    <p class="mt-2">Click "Authorize" to execute the authorization query with the provided policy. You should see "Result: allowed" in the results panel once the policy has been run, which means the authorization query succeeded.</p>
+  </div>
 </div>
     `,
     code: `

--- a/public/content.js
+++ b/public/content.js
@@ -7,19 +7,12 @@ const content = [
     <img class="w-48 inline rounded-md shadow-md dark:border dark:border-gray-700" src="https://meanitsoftware.s3.us-east-1.amazonaws.com/bear1.png" />
   </div>
   <p>Welcome to a tour of the <a class="text-oso-purple-500" href="https://www.osohq.com/docs/modeling-in-polar/reference">Polar authorization language.</a></p>
-  <p class="mt-1">Click <span class="font-bold">Authorize</span> to see if access is granted. Modify the rules and facts to learn!</p>
-
-  <button id="moreContentOpen" class="mt-1 bg-oso-purple-600 hover:bg-oso-purple-500 text-white px-4 py-2 rounded-md disabled:bg-slate-500 dark:bg-oso-purple-800 dark:hover:bg-oso-purple-700">
-    Read More
-  </button>
-  <div id="moreContent" class="hidden">
-    <p class="mt-2">The tour is divided into a list of modules that you can access by clicking on <a class="text-oso-purple-500">A Tour of Polar</a> on the top left of the page. You can also view the table of contents at any time by clicking on the menu on the top right of the page.</p>
-    <p class="mt-2">The code on the right contains a Polar policy. Polar is declarative language designed to express authorization logic in a readable, rule-based format.</p>
-    <p class="mt-2">Polar authorization requests typically take the form "Can this actor perform some action on this resource?" The code on the right contains a minimal policy which indicates that users can read items if they are an admin.</p>
-    <p class="mt-2">Facts define authorization data. This example has one fact by default: user 'alice' has the 'admin' role on the item 'foo'. According to the policy, this means Alice can read Item 'foo'.</p>
-    <img class="mx-auto my-2 w-2/3 cursor-pointer dark:bg-gray-400 rounded-md" src="https://meanitsoftware.s3.us-east-1.amazonaws.com/architecture-diagrams-white.png" onclick="openImageModal(this.src)">
-    <p class="mt-2">Click "Authorize" to execute the authorization query with the provided policy. You should see "Result: allowed" in the results panel once the policy has been run, which means the authorization query succeeded.</p>
-  </div>
+  <p class="mt-2">The tour is divided into a list of modules that you can access by clicking on <a class="text-oso-purple-500">A Tour of Polar</a> on the top left of the page. You can also view the table of contents at any time by clicking on the menu on the top right of the page.</p>
+  <p class="mt-2">The code on the right contains a Polar policy. Polar is declarative language designed to express authorization logic in a readable, rule-based format.</p>
+  <p class="mt-2">Polar authorization requests typically take the form "Can this actor perform some action on this resource?" The code on the right contains a minimal policy which indicates that users can read items if they are an admin.</p>
+  <p class="mt-2">Facts define authorization data. This example has one fact by default: user 'alice' has the 'admin' role on the item 'foo'. According to the policy, this means Alice can read Item 'foo'.</p>
+  <img class="mx-auto my-2 w-2/3 cursor-pointer dark:bg-gray-400 rounded-md" src="https://meanitsoftware.s3.us-east-1.amazonaws.com/architecture-diagrams-white.png" onclick="openImageModal(this.src)">
+  <p class="mt-2">Click "Authorize" to execute the authorization query with the provided policy. You should see "Result: allowed" in the results panel once the policy has been run, which means the authorization query succeeded.</p>
 </div>
     `,
     code: `

--- a/public/index.html
+++ b/public/index.html
@@ -733,8 +733,10 @@ function track(type, data = {}) {
   if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
     return;
   }
-  // Don't show bounce animation anymore
-  localStorage.setItem('seenRunButtonBounce', 'true');
+  if (type !== 'PAGE_LOAD') {
+    // Don't show bounce animation anymore
+    localStorage.setItem('seenRunButtonBounce', 'true');
+  }
 
   const sessionId = sessionStorage.getItem('sessionId') ||
     Math.random().toString(36).slice(2) + Date.now().toString(36);

--- a/public/index.html
+++ b/public/index.html
@@ -72,6 +72,16 @@
       padding: 2px;
       cursor: col-resize;
     }
+
+    @keyframes bounce {
+      0%, 20%, 50%, 80%, 100% {transform: translateY(0);}
+      40% {transform: translateY(-10px);}
+      60% {transform: translateY(-5px);}
+    }
+
+    .bounce {
+      animation: bounce 1s ease infinite;
+    }
   </style>
 </head>
 
@@ -150,8 +160,8 @@
               Authorize
             </button>
           </div>
-          <pre id="results" class="p-4 h-[calc(100%-66px)] overflow-y-auto relative dark:text-gray-300 mr-[1px]">
-            <img src="https://cdn.prod.website-files.com/5f1483105c9a72fd0a3b662a/6793da36f7a5080d73228681_File%20Sharing%20Bear.png" class="absolute bottom-0 h-48 left-1/2 -translate-x-1/2">
+          <pre id="results" class="p-4 h-[calc(100%-66px)] overflow-y-auto relative text-gray-700 dark:text-gray-300 mr-[1px]">
+            <div class="absolute bottom-0 h-48 left-1/2 -translate-x-1/2 text-center"><div>Try clicking "Authorize" to run the check!</div><img src="https://cdn.prod.website-files.com/5f1483105c9a72fd0a3b662a/6793da36f7a5080d73228681_File%20Sharing%20Bear.png" class="h-48 inline"></div>
           </pre>
         </div>
       </div>
@@ -323,6 +333,16 @@ function updatePage(pushState) {
   }
   cm.focus();
 
+  setTimeout(() => {
+    if (document.querySelector('#moreContentOpen')) {
+      document.querySelector('#moreContentOpen').addEventListener('click', function() {
+        track('READ_MORE');
+        document.querySelector('#moreContent').classList.remove('hidden');
+        document.querySelector('#moreContentOpen').classList.add('hidden');
+      });
+    }
+  }, 0);
+
   getFactTypes();
 }
 
@@ -377,6 +397,16 @@ async function getFactTypes() {
     factSelect.appendChild(option);
   }
 }
+
+setTimeout(() => {
+  if (document.querySelector('#moreContentOpen')) {
+    document.querySelector('#moreContentOpen').addEventListener('click', function() {
+      track('READ_MORE');
+      document.querySelector('#moreContent').classList.remove('hidden');
+      document.querySelector('#moreContentOpen').classList.add('hidden');
+    });
+  }
+}, 0);
 
 const factSelect = document.getElementById('factTypeSelect');
 factSelect.addEventListener('change', function onSelectFactType() {
@@ -526,6 +556,19 @@ if (localStorage.getItem('darkMode') === 'true' ||
 } else {
   document.documentElement.classList.remove('dark');
   cm.setOption('theme', 'default');
+}
+
+// Check if the user has seen the runButton bounce animation before
+if (!localStorage.getItem('seenRunButtonBounce')) {
+  document.addEventListener('DOMContentLoaded', () => {
+    const runButton = document.getElementById('runButton');
+    runButton.classList.add('bounce');
+
+    // Remove the bounce after 5 seconds
+    setTimeout(() => {
+      runButton.classList.remove('bounce');
+    }, 10000);
+  });
 }
 
 window.addEventListener('popstate', () => {
@@ -683,6 +726,16 @@ document.getElementById('authorizeQuery').addEventListener('keypress', (e) => {
 });
 
 function track(type, data = {}) {
+  if (document.getElementById('runButton').classList.contains('bounce')) {
+    document.getElementById('runButton').classList.remove('bounce');
+  }
+  // Skip tracking if running on localhost
+  if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+    return;
+  }
+  // Don't show bounce animation anymore
+  localStorage.setItem('seenRunButtonBounce', 'true');
+
   const sessionId = sessionStorage.getItem('sessionId') ||
     Math.random().toString(36).slice(2) + Date.now().toString(36);
   sessionStorage.setItem('sessionId', sessionId);

--- a/public/index.html
+++ b/public/index.html
@@ -333,16 +333,6 @@ function updatePage(pushState) {
   }
   cm.focus();
 
-  setTimeout(() => {
-    if (document.querySelector('#moreContentOpen')) {
-      document.querySelector('#moreContentOpen').addEventListener('click', function() {
-        track('READ_MORE');
-        document.querySelector('#moreContent').classList.remove('hidden');
-        document.querySelector('#moreContentOpen').classList.add('hidden');
-      });
-    }
-  }, 0);
-
   getFactTypes();
 }
 
@@ -397,16 +387,6 @@ async function getFactTypes() {
     factSelect.appendChild(option);
   }
 }
-
-setTimeout(() => {
-  if (document.querySelector('#moreContentOpen')) {
-    document.querySelector('#moreContentOpen').addEventListener('click', function() {
-      track('READ_MORE');
-      document.querySelector('#moreContent').classList.remove('hidden');
-      document.querySelector('#moreContentOpen').classList.add('hidden');
-    });
-  }
-}, 0);
 
 const factSelect = document.getElementById('factTypeSelect');
 factSelect.addEventListener('change', function onSelectFactType() {

--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,7 @@
             </button>
           </div>
           <pre id="results" class="p-4 h-[calc(100%-66px)] overflow-y-auto relative text-gray-700 dark:text-gray-300 mr-[1px]">
-            <div class="absolute bottom-0 h-48 left-1/2 -translate-x-1/2 text-center"><div>Try clicking "Authorize" to run the check!</div><img src="https://cdn.prod.website-files.com/5f1483105c9a72fd0a3b662a/6793da36f7a5080d73228681_File%20Sharing%20Bear.png" class="h-48 inline"></div>
+            <div class="absolute bottom-0 h-48 left-1/2 -translate-x-1/2 text-center"><div>Try clicking "Authorize" to run the authorization query!</div><img src="https://cdn.prod.website-files.com/5f1483105c9a72fd0a3b662a/6793da36f7a5080d73228681_File%20Sharing%20Bear.png" class="h-48 inline"></div>
           </pre>
         </div>
       </div>


### PR DESCRIPTION
Bounce rate is very high, most users don't engage with the app currently:

![image](https://github.com/user-attachments/assets/a57ab017-1fd5-48ad-be21-9789a921355e)

I made a few small tweaks suggested by ChatGPT to reduce bounce rate:

1. Add a bounce animation to "Authorize" to make it clear that's what you should likely try first, bounce animation disappears once the user takes a trackable action.
2. Add some text to the results panel, because right now it isn't clear what the results panel is - just a picture of a bear.
3. Show less text at first unless the user wants to read more. Perhaps all the text + infographic is a little too visually overwhelming at first.